### PR TITLE
Qrl common field controls tests

### DIFF
--- a/src/app/_services/common-field-controls.service.spec.ts
+++ b/src/app/_services/common-field-controls.service.spec.ts
@@ -6,7 +6,10 @@ describe('CommonFieldControlsService', () => {
 
   let service: CommonFieldControlsService;
 
-  beforeEach(() => { service = new CommonFieldControlsService(); });
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.get(CommonFieldControlsService);
+  });
 
   it('#hidePasswordInField should return boolean true', () => {
     expect(service.hidePasswordInField()).toBe(true);
@@ -45,7 +48,6 @@ describe('CommonFieldControlsService', () => {
   });
 
   it('should be created', () => {
-//    const service: CommonFieldControlsService = TestBed.get(CommonFieldControlsService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/_services/common-field-controls.service.spec.ts
+++ b/src/app/_services/common-field-controls.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { Injectable } from '@angular/core';
 
 import { CommonFieldControlsService } from './common-field-controls.service';
 
@@ -7,7 +6,6 @@ describe('CommonFieldControlsService', () => {
 
   let service: CommonFieldControlsService;
 
-//  beforeEach(() => TestBed.configureTestingModule({}));
   beforeEach(() => { service = new CommonFieldControlsService(); });
 
   it('#hidePasswordInField should return boolean true', () => {
@@ -19,12 +17,11 @@ describe('CommonFieldControlsService', () => {
   });
 
   it('#getPasswordFieldType should change after hidePasswordClick(Event)', () => {
-    const comp = new CommonFieldControlsService();
-    expect(comp.getPasswordFieldType()).toBe("password", 'is hidden at first');
-    comp.hidePasswordClick(Event);
-    expect(comp.getPasswordFieldType()).toBe("text", 'is displayed after click');
-    comp.hidePasswordClick(Event);
-    expect(comp.getPasswordFieldType()).toBe("password", 'is hidden after second click');
+    expect(service.getPasswordFieldType()).toBe('password', 'is hidden at first');
+    service.hidePasswordClick(Event);
+    expect(service.getPasswordFieldType()).toBe('text', 'is displayed after click');
+    service.hidePasswordClick(Event);
+    expect(service.getPasswordFieldType()).toBe('password', 'is hidden after second click');
   });
 
   it('#isPasswordField should return boolean true', () => {
@@ -32,25 +29,23 @@ describe('CommonFieldControlsService', () => {
   });
 
   it('#hidePasswordClick(Event) should toggle #hidePassword', () => {
-    const comp = new CommonFieldControlsService();
-    expect(comp.hidePassword).toBe(true, 'password hidden at first');
-    comp.hidePasswordClick(Event);
-    expect(comp.hidePassword).toBe(false, 'password shown after click');
-    comp.hidePasswordClick(Event);
-    expect(comp.hidePassword).toBe(true, 'password hidden after second click');
+    expect(service.hidePassword).toBe(true, 'password hidden at first');
+    service.hidePasswordClick(Event);
+    expect(service.hidePassword).toBe(false, 'password shown after click');
+    service.hidePasswordClick(Event);
+    expect(service.hidePassword).toBe(true, 'password hidden after second click');
   });
 
   it('#getIconVisiblityString should change after hidePasswordClick(Event)', () => {
-    const comp = new CommonFieldControlsService();
-    expect(comp.getIconVisiblityString()).toBe("visibility_off", 'password not visible at first');
-    comp.hidePasswordClick(Event);
-    expect(comp.getIconVisiblityString()).toBe("visibility", 'password displayed after click');
-    comp.hidePasswordClick(Event);
-    expect(comp.getIconVisiblityString()).toBe("visibility_off", 'password hidden after second click');
+    expect(service.getIconVisiblityString()).toBe('visibility_off', 'password not visible at first');
+    service.hidePasswordClick(Event);
+    expect(service.getIconVisiblityString()).toBe('visibility', 'password displayed after click');
+    service.hidePasswordClick(Event);
+    expect(service.getIconVisiblityString()).toBe('visibility_off', 'password hidden after second click');
   });
 
   it('should be created', () => {
-    const service: CommonFieldControlsService = TestBed.get(CommonFieldControlsService);
+//    const service: CommonFieldControlsService = TestBed.get(CommonFieldControlsService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/_services/common-field-controls.service.ts
+++ b/src/app/_services/common-field-controls.service.ts
@@ -5,17 +5,17 @@ import { Injectable } from '@angular/core';
 })
 export class CommonFieldControlsService {
 
-hidePassword:boolean;
+hidePassword: boolean;
 
   constructor() {
     this.hidePassword = true;
   }
 
-  public hidePasswordInField(){
+  public hidePasswordInField() {
     return this.hidePassword = true;
   }
 
-  public showPasswordInField(){
+  public showPasswordInField() {
     return this.hidePassword = false;
   }
 
@@ -28,10 +28,11 @@ hidePassword:boolean;
   }
 
   public hidePasswordClick($event): boolean {
-    if(this.isPasswordField())
+    if (this.isPasswordField()) {
       return this.showPasswordInField();
-    else
+    } else {
       return this.hidePasswordInField();
+    }
   }
 
   public getIconVisiblityString(): string {


### PR DESCRIPTION
Johnathan ( @haxwell ),

This pull request on qrlCommonFieldControlsTest is for a branch off my quizkiRegistrationLogin branch. I put the branch there because the last PR for the quizkiRegistrationLogin was not yet merged, and you had asked for only "one thing" for future PR. 

(Note: Although upgradeToAngular7 branch (and associated PR) was also off quizkiRegistrationLogin, I intentionally did not put the qrlCommonFieldControlsTest on that branch. If I should have, then let me know.)

In this PR for qrlCommonFieldControlsTest , I made the changes you suggested for the common-field-controls.service.spec.ts, then ran the ng tests and ng lint. The common-field-controls.service needed some corrections for both the .ts and spec.ts files to comply with coding standards. I made the changes in both, tested in google, then ran ng test again (34 successes, 0 failures.)

Hope this is what you meant by "one thing". If not, let me know. 

PS. I'll do a similar process to complete the api.service tests ( unless I hear back from you differently of course ) as I want to move forward. 

Happy Holidays! 

Deborah 