### PR TITLE
Qrl app routing tests

### DIFF
--- a/src/app/app-routing.module.spec.ts
+++ b/src/app/app-routing.module.spec.ts
@@ -1,13 +1,136 @@
-import { AppRoutingModule } from './app-routing.module';
+import { Component } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Location } from '@angular/common';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+import { MatButtonModule,
+         MatCardModule,
+         MatCheckboxModule,
+         MatDialogModule,
+         MatExpansionModule,
+         MatFormFieldModule,
+         MatIconModule,
+         MatInputModule,
+         MatListModule,
+         MatMenuModule,
+         MatPaginatorModule,
+         MatSelectModule,
+         MatSidenavModule,
+         MatSortModule,
+         MatTableModule,
+         MatToolbarModule
+       } from '@angular/material';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+
+import { HomePageComponent } from './home-page/home-page.component';
+import { GenerateExamPageComponent } from './generate-exam-page/generate-exam-page.component';
+import { SearchForAnExamPageComponent } from './search-for-an-exam-page/search-for-an-exam-page.component';
+import { CreateExamPageComponent } from './create-exam-page/create-exam-page.component';
+import { CreateQuestionPageComponent } from './create-question-page/create-question-page.component';
+import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
+import { LoginComponent } from './login/login.component';
+import { LoginDialogHostComponent } from './login-dialog-host/login-dialog-host.component';
+import { RegistrationComponent } from './registration/registration.component';
+import { AppRoutingModule, appRoutes } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { NavigationComponent } from './navigation/navigation.component';
+import { NavigationService } from './navigation.service';
+import { DataTableComponent } from './data-table/data-table.component';
+
+// TODO: Ask Johnathan if we even need the questions directory code any more?
+// if not remove questions directory and associated imports and selectors
+import { QuestionsComponent } from './questions/questions.component';
+import { QuestionComponent } from './questions/question/question.component';
+import { QuestionTopicComponent } from './questions/question/question-topics/question-topic/question-topic.component';
+import { QuestionTopicsComponent } from './questions/question/question-topics/question-topics.component';
+import { QuestionReferenceComponent } from './questions/question/question-references/question-reference/question-reference.component';
+import { QuestionReferencesComponent } from './questions/question/question-references/question-references.component';
+import { QuestionChoiceComponent } from './questions/question/question-choices/question-choice/question-choice.component';
+import { QuestionChoicesComponent } from './questions/question/question-choices/question-choices.component';
+
 
 describe('AppRoutingModule', () => {
-  let appRoutingModule: AppRoutingModule;
 
-  beforeEach(() => {
+  let appRoutingModule: AppRoutingModule;
+  let location: Location;
+  let router: Router;
+  let fixture;
+
+  beforeEach(async() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule.withRoutes(appRoutes),
+        BrowserAnimationsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatCheckboxModule,
+        MatDialogModule,
+        MatExpansionModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatListModule,
+        MatMenuModule,
+        MatPaginatorModule,
+        MatSelectModule,
+        MatSidenavModule,
+        MatSortModule,
+        MatTableModule,
+        MatToolbarModule,
+        FormsModule,
+        ReactiveFormsModule
+      ],
+      declarations: [
+        AppComponent,
+        CreateExamPageComponent,
+        CreateQuestionPageComponent,
+        DataTableComponent,
+        GenerateExamPageComponent,
+        HomePageComponent,
+        LoginComponent,
+        LoginDialogHostComponent,
+        PageNotFoundComponent,
+        NavigationComponent,
+        RegistrationComponent,
+        SearchForAnExamPageComponent,
+        QuestionComponent,
+        QuestionsComponent,
+        QuestionTopicComponent,
+        QuestionTopicsComponent,
+        QuestionReferenceComponent,
+        QuestionReferencesComponent,
+        QuestionChoiceComponent,
+        QuestionChoicesComponent
+      ],
+      providers: [
+        { provide: NavigationService,
+          useValue: {
+            setPageTitle: jasmine.createSpy('setPageTitle')
+          }
+        }
+      ]
+    });
     appRoutingModule = new AppRoutingModule();
   });
+
+  beforeEach(() => {
+
+    router = TestBed.get(Router);
+    location = TestBed.get(Location);
+    fixture = TestBed.createComponent(AppComponent);
+    router.initialNavigation();
+  });
+
+  it('#app-rounting navigate to "" redirects to /home-page', fakeAsync(() => {
+    router.navigate(['']);
+    tick();
+    expect(location.path()).toBe('/home-page');
+  }));
 
   it('should create an instance', () => {
     expect(appRoutingModule).toBeTruthy();
   });
+
 });

--- a/src/app/app-routing.module.spec.ts
+++ b/src/app/app-routing.module.spec.ts
@@ -32,6 +32,7 @@ import { CreateQuestionPageComponent } from './create-question-page/create-quest
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { LoginComponent } from './login/login.component';
 import { LoginDialogHostComponent } from './login-dialog-host/login-dialog-host.component';
+import { LoginDialogHostService } from './login-dialog-host/login-dialog-host.service';
 import { RegistrationComponent } from './registration/registration.component';
 import { AppRoutingModule, appRoutes } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -105,9 +106,16 @@ describe('AppRoutingModule', () => {
         QuestionChoicesComponent
       ],
       providers: [
-        { provide: NavigationService,
+        {
+          provide: NavigationService,
           useValue: {
             setPageTitle: jasmine.createSpy('setPageTitle')
+          }
+        },
+        {
+          provide: LoginDialogHostService,
+          useValue: {
+            setRouteOnCloseToUrl: jasmine.createSpy('setRouteOnCloseToUrl')
           }
         }
       ]
@@ -123,13 +131,67 @@ describe('AppRoutingModule', () => {
     router.initialNavigation();
   });
 
-  it('#app-rounting navigate to "" redirects to /home-page', fakeAsync(() => {
+  it('#app-routing navigate to "" redirects to /home-page', fakeAsync(() => {
     router.navigate(['']);
     tick();
     expect(location.path()).toBe('/home-page');
   }));
 
-  it('should create an instance', () => {
+  xit('#app-routing navigate to "home-page" takes you to /home-page', fakeAsync(() => {
+    router.navigate(['/home-page']);
+    tick();
+    expect(location.path()).toBe('/home-page');
+  }));
+
+  xit('#app-routing navigate to "generate-exam-page" takes you to /generate-exam-page', fakeAsync(() => {
+    router.navigate(['/generate-exam-page']);
+    tick();
+    expect(location.path()).toBe('/generate-exam-page');
+  }));
+
+  xit('#app-routing navigate to "search-for-an-exam-page" takes you to /search-for-an-exam-page', fakeAsync(() => {
+    router.navigate(['/search-for-an-exam-page']);
+    tick();
+    expect(location.path()).toBe('/search-for-an-exam-page');
+  }));
+
+  xit('#app-routing navigate to "create-question-page" takes you to /create-question-page', fakeAsync(() => {
+    router.navigate(['/create-question-page']);
+    tick();
+    expect(location.path()).toBe('/create-question-page');
+  }));
+
+  xit('#app-routing navigate to "create-exam-page" takes you to /create-exam-page', fakeAsync(() => {
+    router.navigate(['/create-exam-page']);
+    tick();
+    expect(location.path()).toBe('/create-exam-page');
+  }));
+
+  xit('#app-routing navigate to "login" takes you to /login', fakeAsync(() => {
+    router.navigate(['/login']);
+    tick();
+    expect(location.path()).toBe('/login');
+  }));
+
+  xit('#app-routing navigate to ":dialog101/login" takes you to /:dialog101/login', fakeAsync(() => {
+    router.navigate(['/:dialog101/login']);
+    tick();
+    expect(location.path()).toBe('/:dialog101/login');
+  }));
+
+  xit('#app-routing navigate to "registration" takes you to /registration', fakeAsync(() => {
+    router.navigate(['/registration']);
+    tick();
+    expect(location.path()).toBe('/registration');
+  }));
+
+  it('#app-routing navigate to "**" takes you to /page-not-found', fakeAsync(() => {
+    router.navigate(['/page-not-found']);
+    tick();
+    expect(location.path()).toBe('/page-not-found');
+  }));
+
+  it('#app-routing should create an instance', () => {
     expect(appRoutingModule).toBeTruthy();
   });
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -52,7 +52,7 @@ export const appRoutes: Routes = [
       // { enableTracing: false }
       )
   ],
-  exports: [ RouterModule, appRoutes ]
+  exports: [ RouterModule ]
 })
 
 export class AppRoutingModule { }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,7 +13,7 @@ import { LoginComponent} from './login/login.component';
 import { LoginDialogHostComponent } from './login-dialog-host/login-dialog-host.component';
 import { RegistrationComponent} from './registration/registration.component';
 
-//question imports
+// question imports
 /* saving these imports for use when processing original QuizkiTest functionality
 import { QuestionComponent } from './questions/question/question.component';
 import { QuestionTopicsComponent } from './questions/question/question-topics/question-topics.component';
@@ -28,31 +28,31 @@ import { QuestionTypeComponent } from './questions/question/question-types/quest
 */
 
 
-//for each component page add the path, component, and pageTitle
-const appRoutes: Routes = [
-  { path: 'home-page', component: HomePageComponent, data: {pageTitle: "Home"} },
-  { path: 'generate-exam-page', component: GenerateExamPageComponent, data: {pageTitle: "Generate Exam"} },
-  { path: 'search-for-an-exam-page', component: SearchForAnExamPageComponent, data: {pageTitle: "Search for an Exam"} },
-  { path: 'create-question-page', component: CreateQuestionPageComponent, data: {pageTitle: "Create Question"} },
-  { path: 'create-exam-page', component: CreateExamPageComponent, data: {pageTitle: "Create Exam"} },
-  { path: 'login', component: LoginComponent, data: {pageTitle: "Login"} },
-  { path: ':id/login', component: LoginDialogHostComponent, data: {pageTitle: "Login Dialog"} },
-  { path: 'registration', component: RegistrationComponent, data: {pageTitle: "Register"} },
+// for each component page add the path, component, and pageTitle
+export const appRoutes: Routes = [
+  { path: 'home-page', component: HomePageComponent, data: {pageTitle: 'Home'} },
+  { path: 'generate-exam-page', component: GenerateExamPageComponent, data: {pageTitle: 'Generate Exam'} },
+  { path: 'search-for-an-exam-page', component: SearchForAnExamPageComponent, data: {pageTitle: 'Search for an Exam'} },
+  { path: 'create-question-page', component: CreateQuestionPageComponent, data: {pageTitle: 'Create Question'} },
+  { path: 'create-exam-page', component: CreateExamPageComponent, data: {pageTitle: 'Create Exam'} },
+  { path: 'login', component: LoginComponent, data: {pageTitle: 'Login'} },
+  { path: ':id/login', component: LoginDialogHostComponent, data: {pageTitle: 'Login Dialog'} },
+  { path: 'registration', component: RegistrationComponent, data: {pageTitle: 'Register'} },
 
   // add new pages for the router above this comment line.
   // the empty path should always list as 2nd to last path.
   { path: '', redirectTo: '/home-page', pathMatch: 'full'},
   // Wild card route is always listed last and used when page is not found.
   { path: '**', component: PageNotFoundComponent }
-]
+];
 
 @NgModule({
   imports: [ RouterModule.forRoot(appRoutes,
       // to see the router events change enableTracing: true
-      //{ enableTracing: false }
+      // { enableTracing: false }
       )
   ],
-  exports: [ RouterModule ]
+  exports: [ RouterModule, appRoutes ]
 })
 
 export class AppRoutingModule { }


### PR DESCRIPTION
Johnathan ( @haxwell ),

### Congratulations on the birth of your first child. Can't wait to hear more about her health and health of your wife!

OMG the `qrlAppRoutingTests` PR took me all day to write. What a challenge to me!!!! This PR one is **not ready to merge** because 8 tests are marked as pending because they are triggering an error in the `login-dialog-host` tests. I think that I understand the root cause in the `login-dialog-host`, I may need to rewrite that component and associated service. 

 I successfully ran `ng test` (not marked pending) and `ng lint` correcting both the `app-routing.module.ts` and `app-routing.module.spec.ts`.

**NOW HEAR ME ROAR** 

Until today, I've worked around the code in the `src\app\questions` directory. That directory contains the code written by Jim last spring/summer when we were ramping up with quizki revision (formally titled `QuizkiTest` in the app). Although the code still exists in the project, the code is not currently used. I don't know if Brian or Devon have plans to use the code. To my surprise, the `ApiRoutingModule` tests touched the routes embedded in the code in the `src\app\questions` directory, which is partially why I worked all day to figure out how to write the setup before writing the tests.  If we keep the code, then `src\app\questions` directory code needs to be properly routed with a `QuestionsRoutingModule`. In January (or sooner) we need a decision as to what to do with that code. I vote remove the questions directory (unless Brian or Devon plan to use), and all associated imports before the app continues to grow in complexity. Yet, it is your choice with the teams input.

**Congratulations for the birth of Kaya!** I'm happy for you and Alejandra. Hope she will come home soon.

Deborah