### PR TITLE
Revisit login to fix issue #41, Login does not save all user info returned by backend.

### DIFF
--- a/src/app/login-dialog-host/login-dialog-host.component.spec.ts
+++ b/src/app/login-dialog-host/login-dialog-host.component.spec.ts
@@ -3,9 +3,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoginDialogHostComponent } from './login-dialog-host.component';
 import { MatDialogModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
-//import { Subject } from 'rxjs';
-
-
 
 describe('LoginDialogHostComponent', () => {
   let component: LoginDialogHostComponent;
@@ -17,11 +14,10 @@ describe('LoginDialogHostComponent', () => {
       declarations: [ LoginDialogHostComponent ],
       imports: [
         MatDialogModule ,
-        RouterTestingModule//,
-        //Subject
+        RouterTestingModule
       ],
       providers: [
-        //{ provide: LoginDialogHostService, useValue: { routeToUrl: routeToUrlSpyObj, setRouteOnCloseToUrl: setRouteOnCloseToUrlSpyObj }}
+        // { provide: LoginDialogHostService, useValue: { routeToUrl: routeToUrlSpyObj, setRouteOnCloseToUrl: setRouteOnCloseToUrlSpyObj }}
       ]
 
     })

--- a/src/app/login-dialog-host/login-dialog-host.component.ts
+++ b/src/app/login-dialog-host/login-dialog-host.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -12,7 +12,7 @@ import { LoginDialogHostService } from './login-dialog-host.service';
   styleUrls: ['./login-dialog-host.component.css']
 })
 
-export class LoginDialogHostComponent {
+export class LoginDialogHostComponent implements OnDestroy {
 
   currentDialog: MatDialogRef<LoginComponent> = null;
   destroy = new Subject<any>();
@@ -22,7 +22,7 @@ export class LoginDialogHostComponent {
 
     route.params.pipe(takeUntil(this.destroy))
     .subscribe(params => {
-      if(this.currentDialog) {
+      if ( this.currentDialog ) {
         this.currentDialog.close();
       }
 
@@ -34,8 +34,8 @@ export class LoginDialogHostComponent {
       });
       this.currentDialog.afterClosed().subscribe((result) => {
           router.navigateByUrl(loginDHS.routeToUrl());
-      })
-    })
+      });
+    });
 
    }
 

--- a/src/app/login-dialog-host/login-dialog-host.service.ts
+++ b/src/app/login-dialog-host/login-dialog-host.service.ts
@@ -5,17 +5,17 @@ import { Injectable } from '@angular/core';
 })
 export class LoginDialogHostService {
 
-  routeOnCloseUrl:string;
+  routeOnCloseUrl: string;
 
   constructor() {
     this.setRouteOnCloseToUrl('/home-page');
   }
-  
+
   public routeToUrl(): string {
     return this.routeOnCloseUrl;
   }
 
-  public setRouteOnCloseToUrl(url: string){
+  public setRouteOnCloseToUrl(url: string) {
     this.routeOnCloseUrl = url;
   }
 }

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -18,21 +18,24 @@ import { LoginService } from './login.service';
 import { ApiService } from '../_services/api.service';
 
 import { FormBuilder, FormControl, FormControlName, FormGroup, Validators } from '@angular/forms';
-import {User, Roles} from '../user/user';
+import {User, Role} from '../user/user';
 
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
-  let apiServiceSpyObj = undefined;
-  let dialogRefStub = undefined;
-  let dialogDataStub = undefined;
+  // let apiServiceSpyObj = undefined;
+  // let dialogRefStub = undefined;
+  // let dialogDataStub = undefined;
+  let apiServiceSpyObj;
+  let dialogRefStub;
+  let dialogDataStub;
 
   beforeEach(async(() => {
-    apiServiceSpyObj = jasmine.createSpyObj('apiService', ['get'])
+    apiServiceSpyObj = jasmine.createSpyObj('apiService', ['get']);
 
-    dialogDataStub = jasmine.createSpyObj('loginDialogDataStub',['dialogData'])
-    dialogRefStub = jasmine.createSpyObj('loginDialogRefStub', ['dialogRef'] )
+    dialogDataStub = jasmine.createSpyObj('loginDialogDataStub', ['dialogData']);
+    dialogRefStub = jasmine.createSpyObj('loginDialogRefStub', ['dialogRef'] );
 
     TestBed.configureTestingModule({
       imports : [ ReactiveFormsModule, BrowserAnimationsModule,

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { FormBuilder, FormControl, FormControlName, FormGroup, Validators } from '@angular/forms';
 
-import { LoginService } from './login.service'
-import { User, Roles} from '../user/user';
+import { LoginService } from './login.service';
+import { User, Role} from '../user/user';
 import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { LoginDialogHostService } from '../login-dialog-host/login-dialog-host.service';
 import { CommonFieldControlsService } from '../_services/common-field-controls.service';
@@ -17,8 +17,8 @@ export class LoginComponent implements OnInit {
   username: string;
   password: string;
   loginStatus: string;
-  roles = new Roles(0,"");
-  user = new User(0,this.roles,"","",1,"","",false);
+  role = new Role(0, '');
+  user = new User(0, this.role, '', '', 1, '', '', false);
 
   routeOnCloseUrl: string;
   loginForm: FormGroup;
@@ -30,23 +30,23 @@ export class LoginComponent implements OnInit {
 
   constructor(
       public commonFCS: CommonFieldControlsService,
-      public loginDHS:LoginDialogHostService,
+      public loginDHS: LoginDialogHostService,
       private formBuilder: FormBuilder,
       private loginService: LoginService,
       public dialogRef: MatDialogRef<LoginComponent>, @Inject(MAT_DIALOG_DATA) public data: any
     ) {
-        //console.log('Injected data: ', data)
+        // console.log('Injected data: ', data)
     }
 
   ngOnInit() {
-    this.loginStatus = "Logged Out";
+    this.loginStatus = 'Logged Out';
     this.username = '';
     this.password = '';
     this.loginDHS.setRouteOnCloseToUrl('/home-page');
 
     this.hidePassword = true;
 
-    this.loginErrorMessage = "";
+    this.loginErrorMessage = '';
     this.loginSubmitted = false;
 
     this.loginForm = this.formBuilder.group({
@@ -57,21 +57,21 @@ export class LoginComponent implements OnInit {
 
   //  getter for form fields
    get f() { return this.loginForm.controls; }
-   get valid() {return this.loginForm.valid;}
+   get valid() { return this.loginForm.valid; }
 
   // getters for for form controls by form control name
-   get usernameFC() {return this.loginForm.get('username');}
-   get passwordFC() {return this.loginForm.get('password');}
+   get usernameFC() { return this.loginForm.get('username'); }
+   get passwordFC() { return this.loginForm.get('password'); }
 
 
-   public isInvalidWithTouchedOrDirtyControl(fcName:string):boolean {
+   public isInvalidWithTouchedOrDirtyControl( fcName: string ): boolean {
      return this.loginForm.get(fcName).invalid
         && (this.loginForm.get(fcName).touched || this.loginForm.get(fcName).dirty);
    }
 
   public getLoginErrorMessage(formControlName: string) {
 
-    switch(formControlName){
+    switch ( formControlName ) {
       case 'username':
         this.loginErrorMessage = this.usernameFC.hasError('required') ? 'You must enter a value' :
           this.usernameFC.hasError('minlength') ? 'Username is too short.' :
@@ -83,32 +83,32 @@ export class LoginComponent implements OnInit {
           '';
         break;
       default:
-        this.loginErrorMessage='';
+        this.loginErrorMessage = '';
         break;
       }
       return this.loginErrorMessage;
   }
 
 
-  private cancelLogin(){
+  private cancelLogin() {
     // consider asking the user for cancel confirmation.
     this.loginForm.reset();
 
-    this.username = "";
-    this.password = "";
+    this.username = '';
+    this.password = '';
 
     this.dialogRef.close();
 
   }
 
-  private prepareToTransferToRegistation(){
+  private prepareToTransferToRegistation() {
     // consider asking the user for cancel confirmation.
     this.loginDHS.setRouteOnCloseToUrl('/registration');
-    this.cancelLogin()
+    this.cancelLogin();
   }
 
   private onSubmit() {
-      if(this.loginForm.invalid) { return;} // form should never be invalid at this point.
+      if ( this.loginForm.invalid ) { return; } // form should never be invalid at this point.
       this.loginSubmitted = true;
 
       this.username = this.usernameFC.value;
@@ -118,21 +118,22 @@ export class LoginComponent implements OnInit {
 
   }
 
-  public login(){
+  public login() {
     // need to add an error for when login doesn't occure
-    this.loginStatus = "Requested";
+    this.loginStatus = 'Requested';
     this.loginService.requestUserLogin(this.username, this.password)
       .subscribe(
         (res: User) => {
           this.loginStatus = `${res.name} Logged In`;
+          this.user.setUserData(res);
           this.user.loggedInNow();
         },
         (error) => {
-          this.loginStatus = "Please correct username and password.";
+          this.loginStatus = 'Please correct username and password.';
           this.loginForm.setErrors({'invalid': true});
           this.loginSubmitted = false;
         },
-        () => {this.loginForm.reset(); this.dialogRef.close() }
+        () => {this.loginForm.reset(); this.dialogRef.close(); }
       );
   }
 

--- a/src/app/login/login.service.ts
+++ b/src/app/login/login.service.ts
@@ -11,10 +11,10 @@ export class LoginService {
   constructor(private apiService: ApiService) { }
 
   // method for login an existing user
-  public requestUserLogin(username: string, password: string): Observable<User>{
+  public requestUserLogin(username: string, password: string): Observable<User> {
 
-    //authorization headers are constructed in apiService using username and password
-    let apiVerifyCredentialsUrl: string = '/api/verifyCredentials';
+    // authorization headers are constructed in apiService using username and password
+    const apiVerifyCredentialsUrl = '/api/verifyCredentials';
 
     return this.apiService.get(apiVerifyCredentialsUrl, username, password);
 

--- a/src/app/user/user.ts
+++ b/src/app/user/user.ts
@@ -1,8 +1,16 @@
 
+export class Role {
+  constructor(
+    public id: number,
+    public name: string
+  ){}
+
+}
+
 export class User {
   constructor(
     public id: number,
-    public roles: Roles,
+    public role: Role,
     public password: string,
     public name: string,
     public enabled: number,
@@ -26,31 +34,16 @@ export class User {
     return this.loggedIn;
   }
 
-
   public setUserData(user:User){
     this.id = user.id;
-    this.roles.id = user.roles.id;
-    this.roles.name = user.roles.name;
+    this.role.id = user.role.id;
+    this.role.name = user.role.name;
     this.password = user.password;
     this.name = user.name;
     this.enabled = user.enabled;
     this.email = user.email;
     this.fullname = user.fullname;
-    if (user.demographic !== undefined){
-        this.demographic = user.demographic;
-    }
-    if (user.loggedIn !== undefined){
-        this.loggedIn = user.loggedIn;
-    }
+    this.demographic = user.demographic;
   }
-
-}
-
-
-export class Roles {
-  constructor(
-    public id: number,
-    public name: string
-  ){}
 
 }


### PR DESCRIPTION
Johnathan ( @haxwell )

1) When preparing to write tests for the Login, I noticed the frontend did not save the user info returned by the backend. The `user `method `setUserData(user:user)` existed, but due to oversight is was not called by the login component.  When I added  `this.user.setUserData(res)`, the method erred because the backend used **user.role** (singular), and the frontend used **user.roles** (plural). That meant I needed to fix the user class as well as the login component.

2) As I've started to do before pushing I ran `ng test` and `ng lint `. 

- ng test was successful with tests to date
- ng lint found several issues. Most were minor using ' rather than " , adding white space and adding semicolons. Yet 2 lint comments were significant: a) In one lint comment, had me changed `let `to  `const` and remove type declaration. b) The other lint comment found an incorrect implementation of a lifecyle hook. I had used `ngOnDestroy` without declaring `implements onDestroy` on the class LoginDialogHostComponent.

3) I still may need to change the popup from a route-able popup to a normal popup. Why? Because I believe the route-able popup is what caused issues with 8 app.routing tests that are marked as pending. And we already know I won't be able to reuse the login-dialog-host code as I originally planned. I should have never followed that route-able popup example in the first place. Lesson learned!

If you approve then please merge. I would like the correction merged to dev before creating a branch to finish working with login tests and associated files. If I necessary, I can branch of this one. 

Resolves Issue #41 (created today) : Login does not save all User info returned by backend. 

Thank you,

Deborah 