### PR TITLE
Resolution for Issue LoginDialog #33

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -47,6 +47,7 @@
             aria-label="login button"
             [disabled]="loginForm.invalid || loginSubmitted"
             (click)="onSubmit()"
+            (keyup.enter)="onSubmit()"
             >Login
           </button>
           &nbsp;

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -13,7 +13,8 @@
               <input matInput required minlength
                 type="text" class="form-control" id="username"
                 formControlName="username"
-                placeholder="username">
+                placeholder="username"
+                (keyup.enter)="submitWhenEntireFormIsValid()">
               <mat-error *ngIf="isInvalidWithTouchedOrDirtyControl('username')">
                 {{getLoginErrorMessage("username")}}
               </mat-error>
@@ -27,7 +28,8 @@
               <input matInput required minlength
                 type="password" class="form-control" id="passwordIn"
                 formControlName="password"
-                placeholder="Enter password" [type]="commonFCS.getPasswordFieldType()">
+                placeholder="Enter password" [type]="commonFCS.getPasswordFieldType()"
+                (keyup.enter)="submitWhenEntireFormIsValid()">
               <mat-icon matSuffix (click)="commonFCS.hidePasswordClick($event)">{{commonFCS.getIconVisiblityString()}}</mat-icon>
               <mat-error *ngIf="isInvalidWithTouchedOrDirtyControl('password')">
                 {{getLoginErrorMessage("password")}}

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -115,4 +115,24 @@ describe('LoginComponent', () => {
     expect(errors['minlength']).toBeTruthy();
   });
 
+  it('submitWhenEntireFormIsValid() calls onSubmit() when loginForm is valid', () => {
+    spyOn(component, 'onSubmit');
+    let usernameFormControl = component.loginForm.get('username');
+    let passwordFormControl = component.loginForm.get('password');
+    usernameFormControl.setValue("validUsername");
+    passwordFormControl.setValue("validPassword");
+    component.submitWhenEntireFormIsValid();
+    expect(component.onSubmit).toHaveBeenCalled();
+  });
+
+  it('submitWhenEntireFormIsValid() does not call onSubmit() when loginForm is invalid', () => {
+    spyOn(component, 'onSubmit');
+    let usernameFormControl = component.loginForm.get('username');
+    let passwordFormControl = component.loginForm.get('password');
+    usernameFormControl.setValue("validUsername");
+    passwordFormControl.setValue("bad");
+    component.submitWhenEntireFormIsValid();
+    expect(component.onSubmit).not.toHaveBeenCalled();
+  });
+
 });

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -98,7 +98,7 @@ export class LoginComponent implements OnInit {
 
   }
 
-  private submitWhenEntireFormIsValid() {
+  public submitWhenEntireFormIsValid() {
 
     if (this.loginForm.valid ) { this.onSubmit(); return; }
 
@@ -106,7 +106,7 @@ export class LoginComponent implements OnInit {
 
   }
 
-  private onSubmit() {
+  public onSubmit() {
       if ( this.loginForm.invalid ) { return; } // form should never be invalid at this point.
       this.loginSubmitted = true;
 

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -98,6 +98,14 @@ export class LoginComponent implements OnInit {
 
   }
 
+  private submitWhenEntireFormIsValid() {
+
+    if (this.loginForm.valid ) { this.onSubmit(); return; }
+
+    this.loginStatus = 'Whoops! Please enter valid username and password.';
+
+  }
+
   private onSubmit() {
       if ( this.loginForm.invalid ) { return; } // form should never be invalid at this point.
       this.loginSubmitted = true;


### PR DESCRIPTION
Hi Johnathan,

Please merge or comment.

Branch devFixLoginEnter was created to work on issue Login Dialog #33 which states:

> When I enter the username, and then password, I should be able to hit the Enter key and have it log in, the same as if I had clicked the Login button.

The user could press the enter key when the focus is on either form control field username or password. For instance perhaps the user changes the username after the password is complete. Thus, the entire loginForm group should be valid when the user presses the enter key regardless which form control field has the input focus. Additionally, if the user presses enter, when the focus is on the Login button, then the form should be submitted just as if the Login button was pressed.

To resolve Login Dialog #33 the following actions were taken.

1) added method `public submitWhenEntireFormIsValid()` which when:

- loginForm.valid calls onSubmit() 
- loginForm.invalid updates loginStatus status message 

2) added   (keyup.enter)="submitWhenEntireFormIsValid()" to username and password login form control fields respective `<input>`.

3) added   (keyup.enter)="onSubmit()" to the Login `<button>` .

4) added 2 tests for submitWhenEntireFormIsValid().

In retrospect the same type of logic (yet perhaps more extensive due to the  backend apis)  should be added to the registerForm, thus I will add a new issue for the registration after I hear back from you on this PR.

Deborah